### PR TITLE
Add vi-like j/k selection handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# prompts
+
+
+## 0.2.0
+- Add vi-like j/k selection handling
+
+
+## 0.1.0
+- Initial release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prompts"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Jasmin Bom <jsmnbom@gmail.com>"]
 edition = "2018"
 description = "Interactive prompts for the command line"

--- a/src/select.rs
+++ b/src/select.rs
@@ -197,10 +197,10 @@ impl<T: std::clone::Clone + std::marker::Send + std::fmt::Display> Prompt<T> for
                 KeyCode::End => {
                     self.current = self.choices.len() - 1;
                 }
-                KeyCode::Up => {
+                KeyCode::Char('k') | KeyCode::Up => {
                     self.current = self.current.checked_sub(1).unwrap_or(0);
                 }
-                KeyCode::Down => {
+                KeyCode::Char('j') | KeyCode::Down => {
                     self.current = cmp::min(self.current + 1, self.choices.len() - 1);
                 }
                 _ => {}


### PR DESCRIPTION
This will add the ability to use the common vi-style j/k keys as an alternative to the arrow up/down keys to change the selection when using the Select prompt.

Additionally I would like to also include ctrl-n/ctrl-p (emacs style) as well, but I've omitted that from this PR since that would required a bit more refactoring to the current implementation. 

Also included a changelog and bumped version to 0.2.0.

Please let me know if something isn't quite right and we can discuss the required changes.