### PR TITLE
fix: examples use correct crate name

### DIFF
--- a/examples/autocomplete_tokio.rs
+++ b/examples/autocomplete_tokio.rs
@@ -1,4 +1,4 @@
-use prompt::{autocomplete::AutocompletePrompt, Prompt};
+use prompts::{autocomplete::AutocompletePrompt, Prompt};
 
 #[tokio::main]
 async fn main() {

--- a/examples/confirm_tokio.rs
+++ b/examples/confirm_tokio.rs
@@ -1,4 +1,4 @@
-use prompt::{confirm::ConfirmPrompt, Prompt};
+use prompts::{confirm::ConfirmPrompt, Prompt};
 
 #[tokio::main]
 async fn main() {

--- a/examples/select_custom_type_tokio.rs
+++ b/examples/select_custom_type_tokio.rs
@@ -1,4 +1,4 @@
-use prompt::{select::SelectPrompt, Prompt};
+use prompts::{select::SelectPrompt, Prompt};
 
 #[derive(Clone, Debug)] // Must derive Clone
 struct Person {

--- a/examples/select_simple_tokio.rs
+++ b/examples/select_simple_tokio.rs
@@ -1,4 +1,4 @@
-use prompt::{select::SelectPrompt, Prompt};
+use prompts::{select::SelectPrompt, Prompt};
 
 #[tokio::main]
 async fn main() {

--- a/examples/series_of_prompts.rs
+++ b/examples/series_of_prompts.rs
@@ -1,4 +1,4 @@
-use prompt::{select::SelectPrompt, text::TextPrompt, Prompt};
+use prompts::{select::SelectPrompt, text::TextPrompt, Prompt};
 
 #[tokio::main]
 async fn main() {

--- a/examples/text_simple_tokio.rs
+++ b/examples/text_simple_tokio.rs
@@ -1,4 +1,4 @@
-use prompt::{text::TextPrompt, Prompt};
+use prompts::{text::TextPrompt, Prompt};
 
 #[tokio::main]
 async fn main() {

--- a/examples/text_valid_password_tokio.rs
+++ b/examples/text_valid_password_tokio.rs
@@ -1,4 +1,4 @@
-use prompt::{
+use prompts::{
     text::{Style, TextPrompt},
     Prompt,
 };


### PR DESCRIPTION
The crate was renamed from prompt to prompts at some point, I guess, breaking all the examples. This is a simple rename fix. All the examples run now.